### PR TITLE
make unit test suite pass, rename JobServer to JobBackend, fix default for --job-bakcend

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -52,6 +52,7 @@ from easybuild.tools.run import run_cmd
 _log = fancylogger.getLogger('config', fname=False)
 
 
+DEFAULT_JOB_BACKEND = 'PbsPython'
 DEFAULT_LOGFILE_FORMAT = ("easybuild", "easybuild-%(name)s-%(version)s-%(date)s.%(time)s.log")
 DEFAULT_MNS = 'EasyBuildMNS'
 DEFAULT_MODULE_SYNTAX = 'Tcl'
@@ -67,8 +68,6 @@ DEFAULT_PATH_SUBDIRS = {
 DEFAULT_PREFIX = os.path.join(os.path.expanduser('~'), ".local", "easybuild")
 DEFAULT_REPOSITORY = 'FileRepository'
 DEFAULT_STRICT = run.WARN
-
-PREFERRED_JOB_BACKENDS = ('Pbs', 'GC3Pie')
 
 
 # utility function for obtaining default paths

--- a/easybuild/tools/job/__init__.py
+++ b/easybuild/tools/job/__init__.py
@@ -30,11 +30,10 @@ from abc import ABCMeta, abstractmethod
 from vsc.utils.missing import get_subclasses
 
 from easybuild.tools.config import get_job_backend
-from easybuild.tools.config import PREFERRED_JOB_BACKENDS
 from easybuild.tools.utilities import import_available_modules
 
 
-class JobServer(object):
+class JobBackend(object):
     __metaclass__ = ABCMeta
 
     USABLE = False
@@ -92,9 +91,7 @@ def avail_job_backends(check_usable=True):
     Return all known job execution backends.
     """
     import_available_modules('easybuild.tools.job')
-    class_dict = dict([(x.__name__, x)
-                       for x in get_subclasses(JobServer)
-                       if (x.USABLE or not check_usable)])
+    class_dict = dict([(x.__name__, x) for x in get_subclasses(JobBackend)])
     return class_dict
 
 
@@ -107,16 +104,3 @@ def job_backend():
         return None
     job_backend_class = avail_job_backends().get(job_backend)
     return job_backend_class()
-
-
-def preferred_job_backend(order=PREFERRED_JOB_BACKENDS):
-    """
-    Return name of preferred concrete `JobServer` instance, or `None`
-    if none is available.
-    """
-    available_backends = avail_job_backends()
-    for backend in order:
-        if backend in available_backends:
-            return backend
-            break
-    return None

--- a/easybuild/tools/job/gc3pie.py
+++ b/easybuild/tools/job/gc3pie.py
@@ -44,7 +44,7 @@ except ImportError:
     HAVE_GC3PIE = False
 
 from easybuild.tools.build_log import print_msg
-from easybuild.tools.job import JobServer
+from easybuild.tools.job import JobBackend
 
 from vsc.utils import fancylogger
 
@@ -56,7 +56,7 @@ if HAVE_GC3PIE:
 
 
 # eb --job --job-backend=GC3Pie
-class GC3Pie(JobServer):
+class GC3Pie(JobBackend):
     """
     Use the GC3Pie__ framework to submit and monitor compilation jobs.
 
@@ -83,7 +83,7 @@ class GC3Pie(JobServer):
         Create and return a job object with the given parameters.
 
         First argument `server` is an instance of the corresponding
-        `JobServer` class, i.e., a `GC3Pie`:class: instance in this case.
+        `JobBackend` class, i.e., a `GC3Pie`:class: instance in this case.
 
         Second argument `script` is the content of the job script
         itself, i.e., the sequence of shell commands that will be

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -48,16 +48,15 @@ from easybuild.framework.easyconfig.licenses import license_documentation
 from easybuild.framework.easyconfig.templates import template_documentation
 from easybuild.framework.easyconfig.tools import get_paths_for
 from easybuild.framework.extension import Extension
-from easybuild.tools import build_log, config, run  # @UnusedImport make sure config is always initialized!
+from easybuild.tools import build_log, config, run  # build_log should always stay there, to ensure EasyBuildLog
 from easybuild.tools.build_log import EasyBuildError, raise_easybuilderror
-from easybuild.tools.config import DEFAULT_LOGFILE_FORMAT, DEFAULT_MNS, DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL
-from easybuild.tools.config import DEFAULT_MODULECLASSES, DEFAULT_PATH_SUBDIRS, DEFAULT_PREFIX, DEFAULT_REPOSITORY
-from easybuild.tools.config import DEFAULT_STRICT, get_pretend_installpath, mk_full_default_path
-from easybuild.tools.config import PREFERRED_JOB_BACKENDS
+from easybuild.tools.config import DEFAULT_JOB_BACKEND, DEFAULT_LOGFILE_FORMAT, DEFAULT_MNS, DEFAULT_MODULE_SYNTAX
+from easybuild.tools.config import DEFAULT_MODULES_TOOL, DEFAULT_MODULECLASSES, DEFAULT_PATH_SUBDIRS, DEFAULT_PREFIX
+from easybuild.tools.config import DEFAULT_REPOSITORY, DEFAULT_STRICT, get_pretend_installpath, mk_full_default_path
 from easybuild.tools.configobj import ConfigObj, ConfigObjError
 from easybuild.tools.docs import FORMAT_RST, FORMAT_TXT, avail_easyconfig_params
 from easybuild.tools.github import HAVE_GITHUB_API, HAVE_KEYRING, fetch_github_token
-from easybuild.tools.job import avail_job_backends, preferred_job_backend
+from easybuild.tools.job import avail_job_backends
 from easybuild.tools.modules import avail_modules_tools
 from easybuild.tools.module_generator import ModuleGeneratorLua, avail_module_generators
 from easybuild.tools.module_naming_scheme import GENERAL_CLASS
@@ -249,7 +248,7 @@ class EasyBuildOptions(GeneralOption):
             'installpath-software': ("Install path for software (if None, combine --installpath and --subdir-software)",
                                      None, 'store', None),
             'job-backend': ("What job runner to use", 'choice', 'store',
-                            preferred_job_backend(), (avail_job_backends().keys())),
+                            DEFAULT_JOB_BACKEND, avail_job_backends().keys()),
             # purposely take a copy for the default logfile format
             'logfile-format': ("Directory name and format of the log file",
                                'strtuple', 'store', DEFAULT_LOGFILE_FORMAT[:], {'metavar': 'DIR,FORMAT'}),

--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -72,14 +72,12 @@ def build_easyconfigs_in_parallel(build_command, easyconfigs,
 
     job_server = job_backend()
     if job_server is None:
-        _log.error("Cannot use --job if no job backend is available.")
+        raise EasyBuildError("Cannot use --job if no job backend is available.")
 
     try:
         job_server.begin()
-    except RuntimeError, err:
-        _log.error("connection to server failed (%s: %s), can't submit jobs."
-                   % (err.__class__.__name__, err))
-        return None # XXX: should this `raise` instead?
+    except RuntimeError as err:
+        raise EasyBuildError("connection to server failed (%s: %s), can't submit jobs.", err.__class__.__name__, err)
 
     # dependencies have already been resolved,
     # so one can linearly walk over the list and use previous job id's


### PR DESCRIPTION
Main intention of this is to make the unit test suite pass again, by fixing the (rather poor) test for pbs_python.

I've also renamed a couple of things, let me know if you would rather see things different.

The possible values for `--job-backend` are now `PbsPython` or `GC3Pie`, and if you try to use them when they required support is not available, you'll be informed as soon as you try to use `--job` (not when `eb` is run without `--job`).
